### PR TITLE
Bench2

### DIFF
--- a/game.js
+++ b/game.js
@@ -43,7 +43,10 @@ let newCell = (p, w) => [p, w];
 let groupBy = key => elems => {
     let groups = {}; 
     _r.forEach((ei, i) => {
-        groups[key(ei, i)] = _r.set(i, ei)(groups[key(ei, i)] || {});
+        let gi = groups[key(ei, i)];
+        if (!gi)
+            gi = {}
+        gi[i] = ei;
     })(elems);  
     return groups;
 };

--- a/game.js
+++ b/game.js
@@ -43,10 +43,12 @@ let newCell = (p, w) => [p, w];
 let groupBy = key => elems => {
     let groups = {}; 
     _r.forEach((ei, i) => {
-        let gi = groups[key(ei, i)];
-        if (!gi)
-            gi = {}
-        gi[i] = ei;
+        let k = key(ei, i),
+            gk = groups[k]
+        if (!gk)
+            gk = {}
+        gk[i] = ei;
+        groups[k] = gk;
     })(elems);  
     return groups;
 };


### PR DESCRIPTION
Fix degroup performance... from 1500ms to 12ms ^^

```
// Remember!
_r.reduce((acc, el) => ...) 
```